### PR TITLE
Add Ingress host for the subscription-app frontend

### DIFF
--- a/kubernetes/manifests/development/frontend-ingress.yaml
+++ b/kubernetes/manifests/development/frontend-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: subscription-app-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: subscription-app
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: subscription-frontend-service
+                port:
+                  number: 80

--- a/src/main/java/com/subscription/WebConfig.java
+++ b/src/main/java/com/subscription/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/hello") // Specify the endpoint
-                .allowedOrigins("http://localhost:30002") // Allow requests from your React app
+                .allowedOrigins("http://subscription-app") // Allow requests from your React app
                 .allowedMethods("GET", "POST", "PUT", "DELETE") // Specify allowed methods
                 .allowedHeaders("*"); // Allow all headers
     }


### PR DESCRIPTION
![Screenshot 2024-09-17 at 9 02 06 PM](https://github.com/user-attachments/assets/39baef36-310f-4048-8348-79e746838bcb)


### How to test ?
Recommend using `kubie` for reasy ctx or namespace resolution to set current context
Make sure you're in the correct FE(subscription-app) and BE(subscription-service) namesapces

**_For backend service_**
```
./gradlew clean build
docker build -t subscription-service -f Dockerfile .

cd kubernetes/manifests/development
kubectl apply -f deployment.yaml
kubectl apply -f service.yaml 
```
Hit `http://localhost:30000/hello` and get back 200 response

**_Frontend app_**

```
cd frontend
docker build -t subscription-frontend -f Dockerfile .

cd kubernetes/manifests/development
kubectl apply -f frontend-deployment.yaml
kubectl apply -f frontend-service.yaml
```
Hit `http://localhost:30002/hello` and get back 200 response


**_Ingress_**
Apply this in `subscription-app` namespace

```
sudo nano /etc/hosts
Add to the hosts file 127.0.0.1       subscription-app

cd kubernetes/manifests/development
k apply -f frontend-ingress.yaml
```

Hit `http://subscription-app/` you should see the above image
